### PR TITLE
feat(ark_maps): returns wall tanks to all maps

### DIFF
--- a/_maps/ark_map_files/ark_maps/DeltaStation2.dmm
+++ b/_maps/ark_map_files/ark_maps/DeltaStation2.dmm
@@ -50921,6 +50921,15 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/misc/grass,
 /area/station/service/hydroponics/garden)
+"msW" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/machinery/walltank{
+	pixel_x = -30
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/mechanic/hangar)
 "mta" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/tile/neutral{
@@ -58167,6 +58176,9 @@
 "ojW" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
+	},
+/obj/machinery/walltank{
+	pixel_x = -30
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig_pilot)
@@ -129181,7 +129193,7 @@ lCt
 lUx
 eoB
 rdf
-lzU
+msW
 lzU
 lzU
 lzU

--- a/_maps/ark_map_files/ark_maps/KiloStation2.dmm
+++ b/_maps/ark_map_files/ark_maps/KiloStation2.dmm
@@ -6719,6 +6719,9 @@
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
 	},
+/obj/machinery/walltank{
+	pixel_x = -30
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig_pilot)
 "cij" = (
@@ -41807,6 +41810,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"ncZ" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/machinery/walltank{
+	pixel_x = -30
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/mechanic/hangar)
 "ndz" = (
 /obj/machinery/smartfridge/extract/preloaded,
 /obj/effect/turf_decal/tile/purple/full,
@@ -97532,7 +97544,7 @@ uDX
 xQd
 fHy
 mVT
-wxw
+ncZ
 xeW
 wxw
 wxw

--- a/_maps/ark_map_files/ark_maps/MetaStation.dmm
+++ b/_maps/ark_map_files/ark_maps/MetaStation.dmm
@@ -922,6 +922,9 @@
 	pixel_x = -32;
 	pixel_y = 20
 	},
+/obj/machinery/walltank{
+	pixel_x = -30
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig_pilot)
 "aqs" = (
@@ -27264,6 +27267,9 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
+	},
+/obj/machinery/walltank{
+	pixel_x = -30
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/mechanic/hallway)

--- a/_maps/ark_map_files/ark_maps/NSSJourney.dmm
+++ b/_maps/ark_map_files/ark_maps/NSSJourney.dmm
@@ -33775,6 +33775,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"dvL" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/walltank{
+	pixel_x = 30
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig_pilot)
 "dvO" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
@@ -55286,6 +55295,9 @@
 /obj/item/circuitboard/mecha/spacepod_peri,
 /obj/item/circuitboard/mecha/spacepod_main,
 /obj/item/stack/sheet/glass/fifty,
+/obj/machinery/walltank{
+	pixel_x = -30
+	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/mechanic/hallway)
 "rGH" = (
@@ -85302,7 +85314,7 @@ vEx
 wlx
 gpX
 pvL
-pvL
+dvL
 pvL
 nZn
 pvL

--- a/_maps/ark_map_files/ark_maps/Ouroboros.dmm
+++ b/_maps/ark_map_files/ark_maps/Ouroboros.dmm
@@ -64279,6 +64279,12 @@
 	dir = 4
 	},
 /area/station/security/holding_cell)
+"sIn" = (
+/obj/machinery/walltank{
+	pixel_x = 30
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig_pilot)
 "sIo" = (
 /obj/structure/hedge,
 /obj/structure/window/reinforced/fulltile,
@@ -73210,6 +73216,9 @@
 /area/station/commons/storage/mining)
 "vps" = (
 /obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/walltank{
+	pixel_x = -30
+	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/mechanic/hallway)
 "vpF" = (
@@ -195482,7 +195491,7 @@ fac
 dNm
 dun
 hbK
-bvL
+sIn
 iSU
 xhm
 dun

--- a/_maps/ark_map_files/ark_maps/PubbyStation.dmm
+++ b/_maps/ark_map_files/ark_maps/PubbyStation.dmm
@@ -52842,6 +52842,15 @@
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/hallway/secondary/exit)
+"uMk" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/walltank{
+	pixel_x = 30
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/mechbay)
 "uMo" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/stripes/line,
@@ -53773,6 +53782,12 @@
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/hallway/secondary/exit)
+"vvU" = (
+/obj/machinery/walltank{
+	pixel_x = 30
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/mechanic/hallway)
 "vvY" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -85044,7 +85059,7 @@ ccQ
 acN
 dwq
 iav
-ciF
+vvU
 ciF
 ciF
 utW
@@ -86729,7 +86744,7 @@ aaa
 abN
 vRp
 gfr
-gWG
+uMk
 gWG
 wBY
 vRp

--- a/_maps/ark_map_files/ark_maps/SerenityStation.dmm
+++ b/_maps/ark_map_files/ark_maps/SerenityStation.dmm
@@ -17198,6 +17198,9 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "eDc" = (
 /obj/structure/tank_dispenser/oxygen,
+/obj/machinery/walltank{
+	pixel_x = -30
+	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/mechanic/hangar)
 "eDu" = (
@@ -27329,6 +27332,12 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/security/checkpoint/customs)
+"hiJ" = (
+/obj/machinery/walltank{
+	pixel_x = 30
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig_pilot)
 "hiL" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
@@ -254482,7 +254491,7 @@ cwL
 tFG
 bzE
 tHM
-tHM
+hiJ
 yaA
 tFG
 ksz

--- a/_maps/ark_map_files/ark_maps/VoidRaptor.dmm
+++ b/_maps/ark_map_files/ark_maps/VoidRaptor.dmm
@@ -22255,10 +22255,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/pod/dark,
 /area/station/engineering/storage/tech)
-"gmX" = (
-/obj/machinery/walltank,
-/turf/closed/wall,
-/area/station/security/execution/transfer)
 "gna" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -44155,7 +44151,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint)
 "mbW" = (
-/obj/machinery/status_display/evac/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66554,6 +66549,9 @@
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
+	},
+/obj/machinery/walltank{
+	pixel_x = -30
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
@@ -135822,7 +135820,7 @@ xMq
 xMq
 xMq
 cDj
-gmX
+pQm
 oao
 pQm
 arC

--- a/_maps/ark_map_files/ark_maps/birdshot.dmm
+++ b/_maps/ark_map_files/ark_maps/birdshot.dmm
@@ -3791,7 +3791,6 @@
 	},
 /area/station/hallway/secondary/entry)
 "bEW" = (
-/obj/machinery/light/directional/north,
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/wrench,

--- a/_maps/ark_map_files/ark_maps/north_star.dmm
+++ b/_maps/ark_map_files/ark_maps/north_star.dmm
@@ -20645,6 +20645,13 @@
 	dir = 8
 	},
 /area/station/cargo/drone_bay)
+"fuN" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/machinery/walltank{
+	pixel_x = 30
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/mechanic/hangar)
 "fvb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -83981,6 +83988,9 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/walltank{
+	pixel_x = 30
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig_pilot)
 "vUK" = (
@@ -129083,7 +129093,7 @@ owI
 owI
 owI
 cqm
-wBU
+fuN
 fBX
 kjb
 foI

--- a/_maps/ark_map_files/ark_maps/tramstation.dmm
+++ b/_maps/ark_map_files/ark_maps/tramstation.dmm
@@ -35914,6 +35914,9 @@
 "lef" = (
 /obj/effect/turf_decal/box/white/corners,
 /obj/structure/marker_beacon/burgundy,
+/obj/machinery/walltank{
+	pixel_x = 30
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig_pilot)
 "lej" = (
@@ -55061,6 +55064,15 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"rFr" = (
+/obj/effect/turf_decal/stripes/white/corner{
+	dir = 1
+	},
+/obj/machinery/walltank{
+	pixel_x = 30
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/mechanic/hangar)
 "rGj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
@@ -148768,7 +148780,7 @@ pMW
 pMW
 mxr
 rlS
-lcK
+rFr
 alk
 efl
 mKG

--- a/_maps/ark_map_files/ark_maps/wawastation.dmm
+++ b/_maps/ark_map_files/ark_maps/wawastation.dmm
@@ -10623,6 +10623,9 @@
 /area/station/medical/coldroom)
 "dHV" = (
 /obj/effect/turf_decal/box/white/corners,
+/obj/machinery/walltank{
+	pixel_x = 30
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig_pilot)
 "dHW" = (
@@ -70025,6 +70028,9 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "xPC" = (
 /obj/effect/landmark/start/mechanic,
+/obj/machinery/walltank{
+	pixel_x = -30
+	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/mechanic/hallway)
 "xPH" = (


### PR DESCRIPTION
## О вашем Пулл Реквесте

Вернул на все карты Арка заправки для подов.

Эти карты были подвергнуты изменениям:
Birdshot
Blueshift
DeltaStation
KiloStation
MetaStation
NorthStar
NSSJourney
Ouroboros
PubbyStation
SerenityStation
TramStation
VoidRaptor
WawaStation

Эти карты не используют поды в комнатах пилотов:
IceBoxStation
Snowglobe

Эти карты не были затронуты:
OmegaStation

## Скриншоты и Видео тестирования
-
## Changelog
:cl:
map: Возвращены заправки для подов
/:cl:
